### PR TITLE
Fix food delete

### DIFF
--- a/lib/event-listeners/food-listener.js
+++ b/lib/event-listeners/food-listener.js
@@ -16,7 +16,7 @@ $("#food_form").on("submit", (event) => {
     if (objectHasData(newFood)) {
         clearFormFields()
         createFood(newFood).then((response) => {
-            appendFood(response, "#foodlist")
+            appendFood(response, "#foodlist", "food")
         })
     }
 })


### PR DESCRIPTION
Newly created/appended foods were populating with a undefined page in the class which was rendering the delete button non-functional. Fixed this bug.